### PR TITLE
fix: 修正切换工具后, 因产生重复result而导致无法删除结果的问题

### DIFF
--- a/packages/components/src/store/annotation/reducer.ts
+++ b/packages/components/src/store/annotation/reducer.ts
@@ -320,15 +320,20 @@ export const annotationReducer = (
         return state;
       }
       const [exportResult] = toolInstance?.exportData() ?? [];
-      // console.log("**************************")
-      // console.log(exportResult)
 
       let previousResultList = exportResult;
 
       if (basicResultList?.length > 0) {
         const sourceID = basicResultList[basicIndex]?.id;
         const newResultData = exportResult.map((i: any) => ({ ...i, sourceID }));
-        previousResultList = _.cloneDeep(resultList).filter((i: any) => i.sourceID !== sourceID);
+        previousResultList = _.cloneDeep(resultList).filter((i: any) => {
+          // 修正 https://project.feishu.cn/bigdata_03/issue/detail/3528264?parentUrl=%2Fbigdata_03%2FissueView%2FXARIG5p4g
+          if ((i.sourceID === '' || i.sourceID === undefined) && (sourceID === '' || sourceID === undefined)) {
+            return false;
+          }
+
+          return i.sourceID !== sourceID;
+        });
         previousResultList.push(...newResultData);
       }
       return {


### PR DESCRIPTION
sourceID的判定 `undefined` 和 `''` 可是为相等。