### PR TITLE
fix: 修正目标外标注功能异常

### DIFF
--- a/packages/annotation/src/core/toolOperation/LineToolOperation.ts
+++ b/packages/annotation/src/core/toolOperation/LineToolOperation.ts
@@ -24,7 +24,6 @@ import DrawUtils from '../../utils/tool/DrawUtils';
 import StyleUtils from '../../utils/tool/StyleUtils';
 import AttributeUtils from '../../utils/tool/AttributeUtils';
 import TextAttributeClass from './textAttributeClass';
-import AxisUtils from '@/utils/tool/AxisUtils';
 
 enum EStatus {
   Create = 0,

--- a/packages/annotation/src/core/toolOperation/LineToolOperation.ts
+++ b/packages/annotation/src/core/toolOperation/LineToolOperation.ts
@@ -24,6 +24,7 @@ import DrawUtils from '../../utils/tool/DrawUtils';
 import StyleUtils from '../../utils/tool/StyleUtils';
 import AttributeUtils from '../../utils/tool/AttributeUtils';
 import TextAttributeClass from './textAttributeClass';
+import AxisUtils from '@/utils/tool/AxisUtils';
 
 enum EStatus {
   Create = 0,
@@ -1281,7 +1282,7 @@ class LineToolOperation extends BasicToolOperation {
     this.lineDragging = false;
 
     /** 空格点击为拖拽事件 */
-    if (this.isSpaceKey) {
+    if (this.isSpaceKey || !this.imgInfo) {
       return;
     }
 
@@ -1299,17 +1300,30 @@ class LineToolOperation extends BasicToolOperation {
     }
 
     const nextAxis = this.getNextPoint(e, coord)!;
+    
+    if ((this.isCreate || this.isNone)) {
+      const isPointOutOfBoundary = AxisUtils.isPointOutOfBoundary({
+        coordinate: this.getCoordinateUnderZoom(e),
+        currentPosition: { x: 0, y: 0 },
+        imgInfo: this.imgInfo,
+        drawOutsideTarget: this.config.drawOutsideTarget,
+        basicResult: this.basicResult,
+        zoom: this.zoom,
+      });
 
-    if (this.isCreate || this.isNone) {
+      if (isPointOutOfBoundary) {
+        return;
+      }
+
       this.setCreatStatusAndAddPoint(nextAxis);
       return;
     }
-
+    
     if (this.isActive) {
       if (lineDragging) {
         return;
       }
-
+      
       const isMouseCoordOutsideActiveArea = this.isMouseCoordOutsideActiveArea();
       if (isMouseCoordOutsideActiveArea) {
         this.setNoneStatus(false);

--- a/packages/annotation/src/core/toolOperation/LineToolOperation.ts
+++ b/packages/annotation/src/core/toolOperation/LineToolOperation.ts
@@ -1302,16 +1302,7 @@ class LineToolOperation extends BasicToolOperation {
     const nextAxis = this.getNextPoint(e, coord)!;
     
     if ((this.isCreate || this.isNone)) {
-      const isPointOutOfBoundary = AxisUtils.isPointOutOfBoundary({
-        coordinate: this.getCoordinateUnderZoom(e),
-        currentPosition: { x: 0, y: 0 },
-        imgInfo: this.imgInfo,
-        drawOutsideTarget: this.config.drawOutsideTarget,
-        basicResult: this.basicResult,
-        zoom: this.zoom,
-      });
-
-      if (isPointOutOfBoundary) {
+      if (this.config.drawOutSideTarget && this.isPointOutOfBoundary(this.getCoordinateUnderZoom(e), { x: 0, y: 0 })) {
         return;
       }
 

--- a/packages/annotation/src/core/toolOperation/basicToolOperation.ts
+++ b/packages/annotation/src/core/toolOperation/basicToolOperation.ts
@@ -588,28 +588,36 @@ class BasicToolOperation extends EventListener {
       isOriginalSize,
     );
     // 初始化图片位置信息时，优先从持久化记录中获取
-    const statbleCoord = BasicToolOperation.Cache.get(this._coordinateCacheKey) as ICoordinate;
-    this.setCurrentPos(statbleCoord || currentPos);
-    this.currentPosStorage = statbleCoord || currentPos;
-    let statblezoom = 0;
+    const cachedCoordinate = BasicToolOperation.Cache.get(this._coordinateCacheKey) as ICoordinate;
+    this.setCurrentPos(cachedCoordinate || currentPos);
+    this.currentPosStorage = cachedCoordinate || currentPos;
+    let cachedZoom = 0;
     // 当部位原图比例显示时，采用stable zoom
     if (!isOriginalSize) {
       // 初始化图片缩放信息，优先从持久化记录中获取
-      statblezoom = BasicToolOperation.Cache.get(this._zoomCacheKey) as number;
+      cachedZoom = BasicToolOperation.Cache.get(this._zoomCacheKey) as number;
     } else {
       BasicToolOperation.Cache.set(this._zoomCacheKey, 1);
     }
 
-    this.imgInfo = imgInfo;
-    this.setZoom(statblezoom || zoom);
+    const finalZoom = cachedZoom || zoom;
+    /**
+     * 修正https://project.feishu.cn/bigdata_03/issue/detail/3756207?parentUrl=%2Fbigdata_03%2FissueView%2FXARIG5p4g
+     * 因zoom可被缓存，在切换工具或切换图片列表时需要由缓存后的zoom重新计算imgInfo
+     **/ 
+    this.imgInfo = {
+      width: this.imgNode.width * finalZoom,
+      height: this.imgNode.height * finalZoom,
+    };
+    this.setZoom(finalZoom);
 
-    this.innerZoom = statblezoom || zoom;
+    this.innerZoom = finalZoom;
     this.renderReady = true;
     this.render();
     this.renderBasicCanvas();
 
     this.emit('dependRender');
-    this.emit('renderZoom', zoom);
+    this.emit('renderZoom', finalZoom);
   };
 
   /**

--- a/packages/annotation/src/core/toolOperation/basicToolOperation.ts
+++ b/packages/annotation/src/core/toolOperation/basicToolOperation.ts
@@ -1199,6 +1199,31 @@ class BasicToolOperation extends EventListener {
     return '';
   }
 
+  /**
+   * 判定点是否在边界外
+   * @param coordinate 
+   * @param currentPosition 
+   * @returns boolean
+   */
+  public isPointOutOfBoundary(coordinate: ICoordinate, currentPosition: ICoordinate) {
+    const { zoom, basicResult, imgInfo } = this;
+
+    if (basicResult && zoom) {
+      // brX: basicResult.x
+      const { x: brX, y: brY, width: brW, height: brH } = basicResult;
+      const { x, y } = coordinate;
+      const { x: cX, y: cY } = currentPosition;
+
+      return x - cX > (brX + brW) * zoom || x - cX < brX * zoom || y - cY > (brY + brH) * zoom || y - cY < brY * zoom;
+    } else {
+      const { x, y } = coordinate;
+      const { x: cX, y: cY } = currentPosition;
+      const { width, height } = imgInfo!;
+
+      return x - cX > width || x - cX < 0 || y - cY > height || y - cY < 0;
+    }
+  }
+
   public clearInvalidPage() {
     if (this._invalidDOM && this.container && this.container.contains(this._invalidDOM)) {
       this.container.removeChild(this._invalidDOM);

--- a/packages/annotation/src/core/toolOperation/pointOperation.ts
+++ b/packages/annotation/src/core/toolOperation/pointOperation.ts
@@ -272,14 +272,8 @@ class PointOperation extends BasicToolOperation {
     // 当前目标下没有 hoverId 才进行标注
     if (e.button === 0 && !this.hoverID) {
       // 超出边界则不绘制
-      if (!this.imgInfo || AxisUtils.isPointOutOfBoundary({
-        coordinate: this.getCoordinateUnderZoom(e),
-        currentPosition: { x: 0, y: 0 },
-        imgInfo: this.imgInfo,
-        drawOutsideTarget: this.config.drawOutsideTarget,
-        basicResult: this.basicResult,
-        zoom: this.zoom,
-      })) {
+      // REVIEW: 这里的 config.drawOutsideTarget 跟 lineToolOperation里的 config.drawOutSideTarget 中的「s」大小写不一致
+      if (!this.imgInfo || (this.config.drawOutsideTarget && this.isPointOutOfBoundary(this.getCoordinateUnderZoom(e), { x: 0, y: 0 }))) {
         return;
       }
       

--- a/packages/annotation/src/core/toolOperation/pointOperation.ts
+++ b/packages/annotation/src/core/toolOperation/pointOperation.ts
@@ -271,6 +271,18 @@ class PointOperation extends BasicToolOperation {
 
     // 当前目标下没有 hoverId 才进行标注
     if (e.button === 0 && !this.hoverID) {
+      // 超出边界则不绘制
+      if (!this.imgInfo || AxisUtils.isPointOutOfBoundary({
+        coordinate: this.getCoordinateUnderZoom(e),
+        currentPosition: { x: 0, y: 0 },
+        imgInfo: this.imgInfo,
+        drawOutsideTarget: this.config.drawOutsideTarget,
+        basicResult: this.basicResult,
+        zoom: this.zoom,
+      })) {
+        return;
+      }
+      
       this.createPoint(e);
       this.render();
       // this.container.dispatchEvent(this.saveDataEvent);

--- a/packages/annotation/src/utils/tool/AxisUtils.ts
+++ b/packages/annotation/src/utils/tool/AxisUtils.ts
@@ -63,45 +63,6 @@ export default class AxisUtils {
     return coord;
   }
 
-  /**
-   * 判定点是否在边界外
-   * @returns boolean
-   */
-  public static isPointOutOfBoundary({
-    coordinate,
-    currentPosition,
-    imgInfo,
-    drawOutsideTarget,
-    basicResult,
-    zoom,
-  }: {
-    coordinate: ICoordinate;
-    currentPosition: ICoordinate;
-    imgInfo: ISize;
-    drawOutsideTarget?: boolean;
-    basicResult?: IRect;
-    zoom?: number;
-  }) {
-    if (drawOutsideTarget) {
-      return true;
-    }
-
-    if (basicResult && zoom) {
-      // brX: basicResult.x
-      const { x: brX, y: brY, width: brW, height: brH } = basicResult;
-      const { x, y } = coordinate;
-      const { x: cX, y: cY } = currentPosition;
-
-      return x - cX > (brX + brW) * zoom || x - cX < brX * zoom || y - cY > (brY + brH) * zoom || y - cY < brY * zoom;
-    } else {
-      const { x, y } = coordinate;
-      const { x: cX, y: cY } = currentPosition;
-      const { width, height } = imgInfo;
-
-      return x - cX > width || x - cX < 0 || y - cY > height || y - cY < 0;
-    }
-  }
-
   public static changeCoordinateByRotate(coordinate: ICoordinate, rotate: number, imgSize: ISize) {
     const { width, height } = imgSize;
     const { x, y } = coordinate;

--- a/packages/annotation/src/utils/tool/AxisUtils.ts
+++ b/packages/annotation/src/utils/tool/AxisUtils.ts
@@ -63,6 +63,45 @@ export default class AxisUtils {
     return coord;
   }
 
+  /**
+   * 判定点是否在边界外
+   * @returns boolean
+   */
+  public static isPointOutOfBoundary({
+    coordinate,
+    currentPosition,
+    imgInfo,
+    drawOutsideTarget,
+    basicResult,
+    zoom,
+  }: {
+    coordinate: ICoordinate;
+    currentPosition: ICoordinate;
+    imgInfo: ISize;
+    drawOutsideTarget?: boolean;
+    basicResult?: IRect;
+    zoom?: number;
+  }) {
+    if (drawOutsideTarget) {
+      return true;
+    }
+
+    if (basicResult && zoom) {
+      // brX: basicResult.x
+      const { x: brX, y: brY, width: brW, height: brH } = basicResult;
+      const { x, y } = coordinate;
+      const { x: cX, y: cY } = currentPosition;
+
+      return x - cX > (brX + brW) * zoom || x - cX < brX * zoom || y - cY > (brY + brH) * zoom || y - cY < brY * zoom;
+    } else {
+      const { x, y } = coordinate;
+      const { x: cX, y: cY } = currentPosition;
+      const { width, height } = imgInfo;
+
+      return x - cX > width || x - cX < 0 || y - cY > height || y - cY < 0;
+    }
+  }
+
   public static changeCoordinateByRotate(coordinate: ICoordinate, rotate: number, imgSize: ISize) {
     const { width, height } = imgSize;
     const { x, y } = coordinate;


### PR DESCRIPTION
因增加了zoom缓存，图片信息需要在切换工具或切换左侧图片列表时重新计算。
同时标点工具和标线工具在未开启"目标外标注"时不标点。