### PR TITLE
fix(image-annotator-react): 修复#654问题。1.多标签显示不完整bug 2.图标重叠bug

### DIFF
--- a/packages/image-annotator-react/src/LabelSection/index.tsx
+++ b/packages/image-annotator-react/src/LabelSection/index.tsx
@@ -118,8 +118,9 @@ const MoreAttribute = styled.div<{ visible: boolean }>`
   background-color: #fff;
   right: 0;
   display: flex;
+  flex-wrap: wrap;
   top: 100%;
-  z-index: 999;
+  z-index: 1010;
   padding: 0.5rem;
   box-shadow: 0px 3px 6px 0px rgb(0 0 0 / 21%);
   border-radius: 3px;


### PR DESCRIPTION
[https://github.com/opendatalab/labelU-Kit/issues/654](url)
修复效果：
![image](https://github.com/user-attachments/assets/834fbe02-327b-4fcc-85f3-155708e6032d)
