### PR TITLE
fix(image, image-annotator-react): 修复浏览器缩放/全屏切换后标注框位置偏移

### DIFF
--- a/packages/image-annotator-react/src/hooks/useImageAnnotator.ts
+++ b/packages/image-annotator-react/src/hooks/useImageAnnotator.ts
@@ -11,6 +11,22 @@ export const useImageAnnotator = (containerRef: React.RefObject<HTMLDivElement>,
   const ignoredFirstRun = useRef<boolean>(true);
 
   useLayoutEffect(() => {
+    const handleResize = () => {
+      if (!containerRef.current || !engine) {
+        return;
+      }
+
+      const width = containerRef.current.clientWidth;
+      const height = containerRef.current.clientHeight;
+
+      engine.resize(width, height);
+
+      // 需要加载图片后才能居中，否则标注坐标计算会有误差
+      if (engine.backgroundRenderer?.image) {
+        engine.center();
+      }
+    };
+
     const resizeObserver = new ResizeObserver((entries) => {
       if (entries.length === 0) {
         return;
@@ -23,21 +39,28 @@ export const useImageAnnotator = (containerRef: React.RefObject<HTMLDivElement>,
         return;
       }
 
-      const height = entries[0].contentRect.height;
-      const width = entries[0].contentRect.width;
-
-      engine?.resize(width, height);
-
-      // 需要加载图片后才能居中，否则标注坐标计算会有误差
-      if (engine?.backgroundRenderer?.image) {
-        engine?.center();
-      }
+      handleResize();
     });
 
     resizeObserver.observe(containerRef.current as HTMLElement);
 
+    // 监听 devicePixelRatio 变化（浏览器缩放、全屏切换等场景）
+    let dprMediaQuery: MediaQueryList | null = null;
+    const handleDprChange = () => {
+      handleResize();
+
+      // dpr 变化后需要重新监听新的 dpr 值
+      dprMediaQuery?.removeEventListener('change', handleDprChange);
+      dprMediaQuery = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
+      dprMediaQuery.addEventListener('change', handleDprChange);
+    };
+
+    dprMediaQuery = window.matchMedia(`(resolution: ${window.devicePixelRatio}dppx)`);
+    dprMediaQuery.addEventListener('change', handleDprChange);
+
     return () => {
       resizeObserver.disconnect();
+      dprMediaQuery?.removeEventListener('change', handleDprChange);
     };
   }, [containerRef, engine]);
 

--- a/packages/image/src/core/Renderer.ts
+++ b/packages/image/src/core/Renderer.ts
@@ -66,6 +66,9 @@ export class Renderer extends EventEmitter {
   public resize(width: number, height: number) {
     const { canvas } = this;
 
+    // 每次 resize 时重新获取 devicePixelRatio，避免浏览器缩放或全屏切换后坐标偏移
+    this.ratio = window.devicePixelRatio || 1;
+
     canvas.width = width * this.ratio;
     canvas.height = height * this.ratio;
     canvas.style.width = `${width}px`;


### PR DESCRIPTION
- Renderer.resize() 中重新获取 devicePixelRatio，避免使用构造时的缓存值
- useImageAnnotator 新增 matchMedia 监听 devicePixelRatio 变化，在浏览器缩放或全屏切换时自动触发 resize 重新校准坐标