### PR TITLE
feat(frontend): accept webp images

### DIFF
--- a/apps/frontend/src/constants/mediaType.ts
+++ b/apps/frontend/src/constants/mediaType.ts
@@ -9,13 +9,13 @@ export const MediaTypeText = {
 };
 
 export const FileExtensionText = {
-  [MediaType.IMAGE]: 'jpg、jpeg、png、bmp、gif',
+  [MediaType.IMAGE]: 'jpg、jpeg、png、bmp、gif、webp',
   [MediaType.VIDEO]: 'mp4(h.264)',
   [MediaType.AUDIO]: 'mp3、wav、ogg、m4a',
 };
 
 export const FileExtension = {
-  [MediaType.IMAGE]: ['jpg', 'png', 'bmp', 'gif', 'jpeg'],
+  [MediaType.IMAGE]: ['jpg', 'png', 'bmp', 'gif', 'jpeg', 'webp'],
   [MediaType.VIDEO]: ['mp4'],
   [MediaType.AUDIO]: ['mp3', 'wav', 'ogg', 'm4a'],
 };
@@ -27,7 +27,7 @@ export const MediaRouterPrefix = {
 };
 
 export const FileMimeType = {
-  [MediaType.IMAGE]: 'image/png,image/jpeg,image/bmp,image/gif',
+  [MediaType.IMAGE]: 'image/png,image/jpeg,image/bmp,image/gif,image/webp',
   [MediaType.VIDEO]: 'video/mp4',
   [MediaType.AUDIO]: 'audio/mpeg,audio/x-wav,audio/vnd.wav,audio/ogg,audio/x-m4a',
 };


### PR DESCRIPTION
Everything downstream already handles webp: the backend gates uploads on content_type starting with "image/" rather than an extension allowlist, create_thumbnail_bytes maps .webp to WEBP, the S3 datasource importer lists it in IMAGE_EXTENSIONS, and Pillow decodes it (so auto-labelling works). Only the frontend list left it out, which is also why webp arriving via an S3 datasource already worked while a local upload of the same file did not.

All three entries move together: FileExtension is the actual check (commonController.isCorrectFileType, and the S3 import filter), FileMimeType is the picker filter, and FileExtensionText is the message shown when a file is rejected -- changing one without the others gives a file that can be picked but not accepted, or a tip that contradicts it.

Note animated webp is flattened to its first frame by Pillow, the same as the already-accepted gif.